### PR TITLE
close #520

### DIFF
--- a/platform-visualization/src/session.js
+++ b/platform-visualization/src/session.js
@@ -147,7 +147,9 @@ function Session(){
          			$("#logout").fadeIn(2000);
 
          			drawUser(usr);
-                    setToken(tkn);   
+                    setToken(tkn); 
+
+                    window.getData();  
                 }
                 else {
     				console.log("Error:", tkn);
@@ -169,9 +171,9 @@ function Session(){
             $("#logout").fadeIn(2000);
 
             drawUser(usr);
-        }
 
-        window.getData();
+            window.getData();
+        }
 
 	};
 


### PR DESCRIPTION
getData was being executed ahead of time; when the user logged in via GitHub the helper didn't recognized that the user had login and the access key used with the api wasn't being set.
