### PR TITLE
#649

### DIFF
--- a/clair/src/headers.js
+++ b/clair/src/headers.js
@@ -24,6 +24,7 @@ function Headers(columnWidth, superLayerMaxHeight, groupsQtty, layersQtty, super
         },
         self = this,
         graph = {},
+        status = [],
         arrows = [];
 
     var width = columnWidth * window.TILE_DIMENSION.width;
@@ -32,13 +33,68 @@ function Headers(columnWidth, superLayerMaxHeight, groupsQtty, layersQtty, super
     this.dep = dependencies;
     this.arrows = arrows;
     this.arrowPositions = arrowsPositions;
+    this.status = status;
 
     var onClick = function(target) {
         if(window.actualView === 'workflows'){
             window.buttonsManager.removeAllButtons();
             onElementClickHeader(target.userData.id, objects);
         }
+        if(window.actualView === 'table'){
+            if(status.length === 0){
+                tileVisibility(target.userData.id, 'show');
+                status[target.userData.id] = 'on';
+            }
+            else{
+                if(status[target.userData.id] === 'on'){
+                    tileVisibility(target.userData.id, 'hide');
+                    status[target.userData.id] = 'off';
+                    self.signs();
+                }
+                else{
+                    tileVisibility(target.userData.id, 'show');
+                    status[target.userData.id] = 'on';
+                }
+            }
+            self.signs();
+        }
     };
+
+    this.hideTable = function(){
+        for(i = 0, l = objects.length; i < l; i++){
+            if(status[i] === 'on'){
+                tileVisibility(i, 'hide');
+                status[i] = 'off';
+            }
+        }
+        self.signs();
+    }
+
+    this.createComp = function(id){
+        var res = id.slice(0,3);
+        for(i = 0, l = objects.length; i < l; i++){
+            if(objects[i].name === res){
+                if(status[i] === 'off'){
+                    tileVisibility(i, 'show');
+                    status[i] = 'on';
+                    self.signs();
+                }
+            }
+        }
+    }
+
+    this.signs = function(){
+        for(i = 0, l = objects.length; i < l; i++){
+            if(status[i] === 'on')
+                window.signLayer.transformSignLayer(objects[i].name, 'set');
+            else
+                window.signLayer.transformSignLayer(objects[i].name, 'remove');
+        }
+    }
+
+    function tileVisibility(id, visibility){
+        window.tileManager.materialize(visibility, id);
+    }
 
     function onElementClickHeader(id, objects)
     {
@@ -745,6 +801,9 @@ function Headers(columnWidth, superLayerMaxHeight, groupsQtty, layersQtty, super
                 createChildren(slayer, headerData.dependsOn);
             }
         }
+
+        for(i = 0, l = objects.length; i < l; i++)
+            status.push('off');
 
         buildGraph();
         calculateStackPositions();

--- a/clair/src/screenshots.js
+++ b/clair/src/screenshots.js
@@ -51,8 +51,6 @@ function ScreenshotsAndroid() {
 						self.objects.target[i].show.x = target.x;
 						self.objects.target[i].show.y = target.y;
 						self.objects.target[i].show.z = target.z;
-
-						animate(mesh, target.show);
 					}
 				}
 			}

--- a/clair/src/signLayer.js
+++ b/clair/src/signLayer.js
@@ -167,21 +167,36 @@ function SignLayer(){
 		return mesh;
 	};
 
-	this.transformSignLayer = function(){
-		
-		var duration = 3000;
+	this.transformSignLayer = function(name,option){
+        
+        var duration = 5000;
 
-		for(var i = 0, l = objects.length; i < l; i++) {
-            new TWEEN.Tween(objects[i].position)
-            .to({
-                x : positions.target[i].x,
-                y : positions.target[i].y,
-                z : positions.target[i].z
-            }, Math.random() * duration + duration)
-            .easing(TWEEN.Easing.Exponential.InOut)
-            .start();
+        for(var i = 0, l = objects.length; i < l; i++) {
+            var res = objects[i].name.slice(0,3);
+            if(res === name){
+                if(option === 'set'){
+                    new TWEEN.Tween(objects[i].position)
+                    .to({
+                        x : positions.target[i].x,
+                        y : positions.target[i].y,
+                        z : positions.target[i].z
+                    }, Math.random() * duration + duration)
+                    .easing(TWEEN.Easing.Exponential.InOut)
+                    .start();
+                }
+                else{
+                    new TWEEN.Tween(objects[i].position)
+                    .to({
+                        x : positions.lastTarget[i].x,
+                        y : positions.lastTarget[i].y,
+                        z : positions.lastTarget[i].z
+                    }, Math.random() * duration + duration)
+                    .easing(TWEEN.Easing.Exponential.InOut)
+                    .start();
+                }
+            }
         }
-	};
+    };
 
 	this.letAloneSignLayer = function(){
 

--- a/clair/src/tableEdit.js
+++ b/clair/src/tableEdit.js
@@ -369,9 +369,7 @@ function TableEdit() {
                     window.camera.move(target.show.position.x, target.show.position.y, target.show.position.z + 8000, 3000);
 
                     animate(mesh, target.show, 3500, function(){
-
                         window.screenshotsAndroid.hidePositionScreenshots(platform, layer); 
-                        window.tileManager.updateElementsByGroup();
                     });
 
                     setTimeout( function() {
@@ -387,7 +385,7 @@ function TableEdit() {
                     }, 2000 );
                             
                     window.TABLE[platform].layers[layer].objects.push(object);
-
+                    window.tileManager.updateElementsByGroup();
                 });
             },
             function(){
@@ -557,9 +555,7 @@ function TableEdit() {
 
                             positionCameraX = window.TABLE[newGroup].x;
                             positionCameraY = transformPositionY(window.helper.getPositionYLayer(newLayer));
-
                             camera.move(positionCameraX, positionCameraY,8000, 2000);
-
                             createNewElementTile(table);
                             window.screenshotsAndroid.hidePositionScreenshots(newGroup, newLayer);
                             window.tileManager.updateElementsByGroup();
@@ -844,9 +840,7 @@ function TableEdit() {
 
                     var target =  window.helper.fillTarget(0, 0, 160000, 'table');
 
-                    animate(mesh, target.hide, 1500, function(){
-                        window.scene.remove(mesh);
-                    });
+                    window.scene.remove(mesh);
 
                     arrayObject.splice(id, 1);
 

--- a/clair/src/tileManager.js
+++ b/clair/src/tileManager.js
@@ -577,13 +577,12 @@ function TileManager() {
      * @param {Array}  goal     Member of ViewManager.targets
      * @param {Number} duration Milliseconds of animation
      */
-    this.transform = function (ordered, duration) {
+    this.transform = function (duration) {
 
         var i, l, j,
             DELAY = 500;
 
-        duration = duration || 2000;
-        ordered = ordered || false;
+        duration = duration || 1000;
 
         //TWEEN.removeAll();
 
@@ -615,33 +614,20 @@ function TileManager() {
             return move;
         };
 
-        if(ordered === true) {
+        for(i = 0; i < self.elementsByGroup.length; i++) {
 
-            for(i = 0; i < self.elementsByGroup.length; i++) {
+            var k = (i + self.elementsByGroup.length - 1) % (self.elementsByGroup.length);
+            var delay = i * DELAY;
 
-                var k = (i + self.elementsByGroup.length - 1) % (self.elementsByGroup.length);
-                var delay = i * DELAY;
-
+            if(window.headers.status[k] === 'on'){
                 for(j = 0; j < self.elementsByGroup[k].length; j++) {
 
                     var index = self.elementsByGroup[k][j];
-
                     var target = window.helper.getSpecificTile(index);
-
                     var animation = animate(target.mesh, target.target.show, delay);
-
                     animation.start();
-                    
+     
                 }
-            }
-        }
-        else {
-
-            for(var r = 0; r < window.tilesQtty.length; r++){
-
-                var tile = window.helper.getSpecificTile(window.tilesQtty[r]);
-
-                animate(tile.mesh, tile.target.show, 0).start();
             }
         }
 
@@ -657,8 +643,6 @@ function TileManager() {
             .to({}, duration * 2 + self.elementsByGroup * DELAY)
             .onUpdate(render)
             .start();
-
-        setTimeout(window.screenshotsAndroid.show, duration);
     };
 
     /**
@@ -977,5 +961,54 @@ function TileManager() {
             }
         }
         return dev;
+    }
+
+    this.materialize = function (visibility, id){
+
+        var noitamina = function(object, target, delay) {
+
+            delay = delay || 0;
+
+            var duration = 2000;
+
+             var move = new TWEEN.Tween(object.position)
+                        .to({
+                            x: target.position.x,
+                            y: target.position.y,
+                            z: target.position.z
+                        }, Math.random() * duration + duration)
+                        .easing(TWEEN.Easing.Exponential.InOut)
+                        .delay(delay)
+                        .onUpdate(render)
+                        .onComplete(function() { object.userData.flying = false; });
+
+            var rotation = new TWEEN.Tween(object.rotation)
+                            .to({
+                                x: target.rotation.x,
+                                y: target.rotation.y,
+                                z: target.rotation.z
+                            }, Math.random() * duration + duration)
+                            .delay(delay)
+                            .onUpdate(render)
+                            .easing(TWEEN.Easing.Exponential.InOut);
+
+            move.onStart(function() { rotation.start(); });
+
+            return move;
+        };
+
+        var delay = 500;
+        
+        for(var j = 0; j < self.elementsByGroup[id].length; j++) {
+            var index = self.elementsByGroup[id][j];
+            var target = window.helper.getSpecificTile(index);
+
+            if(visibility === 'show')
+                var animation = noitamina(target.mesh, target.target.show, delay);
+            else
+                var animation = noitamina(target.mesh, target.target.hide, delay);
+
+            animation.start();   
+        }
     }
 }

--- a/clair/src/viewManager.js
+++ b/clair/src/viewManager.js
@@ -58,11 +58,7 @@ function ViewManager() {
                         window.tableEdit.addButton();
 
                         window.tileManager.transform(true, 3000 + transition);
-
-                        setTimeout(function(){
-                            window.signLayer.transformSignLayer();
-                         }, 9500);
-
+                        
                         //Special: If coming from home, delay the animation
                         if(window.actualView === 'home')
                             transition = transition + 3000;
@@ -72,31 +68,18 @@ function ViewManager() {
                         window.developer.delete();
                     };
 
-                    backButton = function() {
-
+                    backButton = function() {   
                         window.changeView();
-
-                        setTimeout(function(){
-                            window.signLayer.transformSignLayer();
-                        }, 2500);
-
-                        window.developer.delete();
-                    };
+                    };  
 
                     exit = function() {
+                        window.headers.hideTable();
                         window.tileManager.rollBack();
-
                         buttonsManager.removeAllButtons();
                     };
 
                     reset = function() {
                         window.tileManager.rollBack();
-
-                        window.headers.transformTable(2000);
-
-                        setTimeout(function(){
-                            window.signLayer.transformSignLayer();
-                         }, 3000);
                     };
 
                     break;

--- a/clair/src/viewer.js
+++ b/clair/src/viewer.js
@@ -253,8 +253,9 @@ function changeView() {
     window.workFlowManager.getActualFlow();
 
     window.headers.transformTable(1500);
+    window.headers.signs();
 
-    window.tileManager.transform(1500);
+    window.tileManager.transform(800);
 
 }
 


### PR DESCRIPTION
Clicking on a group header will show/hide it's corresponding tiles. For now the view will retain the headers transformation as a table.

Note: This is the work before the merge between #stack and #table. As that will take longer, this change will reduce the resources needed on the Architecture visualization on the meantime.
